### PR TITLE
Update custom_switch.dart

### DIFF
--- a/lib/custom_switch.dart
+++ b/lib/custom_switch.dart
@@ -44,6 +44,12 @@ class _CustomSwitchState extends State<CustomSwitch>
         .animate(CurvedAnimation(
             parent: _animationController, curve: Curves.linear));
   }
+  
+  @override
+  void dispose() {
+    _animationController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
Updated with this fix - https://stackoverflow.com/questions/58802223/flutter-ticker-must-be-disposed-before-calling-super-dispose